### PR TITLE
Integrate cvat infrastructure into Weed-AI docker compose

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "search/cvat"]
+	path = search/cvat
+	url = https://github.com/Weed-AI/cvat

--- a/search/README.md
+++ b/search/README.md
@@ -26,6 +26,9 @@ FROM_EMAIL=Sender Name <sender@host>
 # The following works when they are local directories on the host, which are periodically rsynced to a remote
 GIT_REMOTE_PATH=/path/to/git/remote/on/rds
 DVC_REMOTE_PATH=/path/to/dvc/remote/on/rds
+# The following is to let traefik know which hosts are legit
+HTTP_HOST=<http host>
+HTTPS_HOST=<https host such as weed-ai.sydney.edu.au>
 ```
 
 ### Initialise database, migrate and create superuser
@@ -38,4 +41,12 @@ DVC_REMOTE_PATH=/path/to/dvc/remote/on/rds
 	1. Start Django server: `docker-compose -f docker-compose-dev.yml up db django`
 	2. Enter server container: `docker exec -it django bash`
 	3. Create superuser: `python manage.py createsuperuser` and follow the prompt instruction
+
+### To build cvat image
+```
+# To also download cvat as a submodule
+git clone --recurse-submodules -j8 git@github.com:Weed-AI/Weed-AI.git
+cd cvat
+docker-compose build cvat_ui
+# Then start WeedAI as above
 ```

--- a/search/docker-compose-dev.yml
+++ b/search/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.3"
 
 x-logging: 
   &default-logging
@@ -154,7 +154,7 @@ services:
        - ./:/code # for development, unused in production
        - /code/node_modules # an exception from the above volume
     ports:
-      - "8080:80"
+      - "8081:80"
     environment:
       - NODE_ENV=development
     networks:
@@ -163,6 +163,96 @@ services:
     depends_on:
       - elasticsearch
     logging: *default-logging
+
+  cvat_db:
+    container_name: weedai_cvat_db
+    image: postgres:10-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_DB: cvat
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - cvat_db:/var/lib/postgresql/data
+    networks:
+      - elastic
+
+  cvat_redis:
+    container_name: weedai_cvat_redis
+    image: redis:4.0-alpine
+    restart: always
+    networks:
+      - elastic
+
+  cvat:
+    container_name: weedai_cvat
+    image: openvino/cvat_server
+    restart: always
+    depends_on:
+      - cvat_redis
+      - cvat_db
+    environment:
+      DJANGO_MODWSGI_EXTRA_ARGS: ''
+      ALLOWED_HOSTS: '*'
+      CVAT_REDIS_HOST: 'cvat_redis'
+      CVAT_POSTGRES_HOST: 'cvat_db'
+      ADAPTIVE_AUTO_ANNOTATION: 'false'
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.cvat.loadbalancer.server.port=8080
+      - traefik.http.routers.cvat.rule=Host(`${CVAT_HOST:-localhost}`) &&
+          PathPrefix(`/annotation/api/`, `/annotation/git/`, `/annotation/opencv/`, `/annotation/analytics/`, `/annotation/static/`, `/annotation/admin`, `/annotation/documentation/`, `/annotation/django-rq`)
+      - traefik.http.routers.cvat.entrypoints=web
+      - traefik.http.routers.cvat.middlewares=add-cvat
+      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/annotation
+      - traefik.http.middlewares.add-cvat.stripprefix.forceSlash=true
+    volumes:
+      - cvat_data:/home/django/data
+      - cvat_keys:/home/django/keys
+      - cvat_logs:/home/django/logs
+    networks:
+      - elastic
+
+  cvat_ui:
+    container_name: weedai_cvat_ui
+    image: openvino/cvat_ui
+    restart: always
+    depends_on:
+      - cvat
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.cvat-ui.loadbalancer.server.port=80
+      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.cvat-ui.entrypoints=web
+      - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/annotation
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.forceSlash=true
+    networks:
+      - elastic
+
+  traefik:
+    image: traefik:v2.4
+    container_name: weedai_traefik
+    restart: always
+    command:
+      - "--providers.docker.exposedByDefault=false"
+      - "--providers.docker.network=elastic"
+      - "--entryPoints.web.address=:8080"
+    # Uncomment to get Traefik dashboard
+    #   - "--entryPoints.dashboard.address=:8090"
+    #   - "--api.dashboard=true"
+    # labels:
+    #   - traefik.enable=true
+    #   - traefik.http.routers.dashboard.entrypoints=dashboard
+    #   - traefik.http.routers.dashboard.service=api@internal
+    #   - traefik.http.routers.dashboard.rule=Host(`${CVAT_HOST:-localhost}`)
+    ports:
+      - 8080:8080
+      - 8090:8090
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - elastic
 
 networks:
   elastic:
@@ -183,3 +273,7 @@ volumes:
     driver: local
   mystatic_dir:
     driver: local
+  cvat_db:
+  cvat_data:
+  cvat_keys:
+  cvat_logs:

--- a/search/docker-compose-dev.yml
+++ b/search/docker-compose-dev.yml
@@ -204,10 +204,10 @@ services:
       - traefik.enable=true
       - traefik.http.services.cvat.loadbalancer.server.port=8080
       - traefik.http.routers.cvat.rule=Host(`${HTTP_HOST:-localhost}`) &&
-          PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
+          PathPrefix(`${CVAT_BASEPATH}/api/`, `${CVAT_BASEPATH}/git/`, `${CVAT_BASEPATH}/opencv/`, `${CVAT_BASEPATH}/analytics/`, `${CVAT_BASEPATH}/static/`, `${CVAT_BASEPATH}/admin`, `${CVAT_BASEPATH}/documentation/`, `${CVAT_BASEPATH}/django-rq`)
       - traefik.http.routers.cvat.entrypoints=web
       - traefik.http.routers.cvat.middlewares=add-cvat
-      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/cvat-annotation
+      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=${CVAT_BASEPATH}
       - traefik.http.middlewares.add-cvat.stripprefix.forceSlash=true
     volumes:
       - cvat_data:/home/django/data
@@ -226,10 +226,10 @@ services:
       - traefik.enable=true
       - traefik.http.services.cvat-ui.loadbalancer.server.port=80
       - traefik.http.routers.cvat-ui.rule=Host(`${HTTP_HOST:-localhost}`) &&
-          PathPrefix(`/cvat-annotation`, `/cvat-ui`)
+          PathPrefix(`${CVAT_BASEPATH}`, `/cvat-ui`)
       - traefik.http.routers.cvat-ui.entrypoints=web
       - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui
-      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/cvat-annotation
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=${CVAT_BASEPATH}
       - traefik.http.middlewares.add-cvat-ui.stripprefix.forceSlash=true
     networks:
       - elastic

--- a/search/docker-compose-dev.yml
+++ b/search/docker-compose-dev.yml
@@ -20,7 +20,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.nginx.loadbalancer.server.port=80
-      - traefik.http.routers.nginx.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.nginx.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`)
       - traefik.http.routers.nginx.entrypoints=web
     volumes:
       # Static file service
@@ -203,7 +203,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat.loadbalancer.server.port=8080
-      - traefik.http.routers.cvat.rule=Host(`${CVAT_HOST:-localhost}`) &&
+      - traefik.http.routers.cvat.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`) &&
           PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
       - traefik.http.routers.cvat.entrypoints=web
       - traefik.http.routers.cvat.middlewares=add-cvat
@@ -225,7 +225,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat-ui.loadbalancer.server.port=80
-      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`) &&
+      - traefik.http.routers.cvat-ui.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`) &&
           PathPrefix(`/cvat-annotation`, `/cvat-ui`)
       - traefik.http.routers.cvat-ui.entrypoints=web
       - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui

--- a/search/docker-compose-dev.yml
+++ b/search/docker-compose-dev.yml
@@ -14,11 +14,14 @@ services:
         - reactivesearch
     build:
         context: ./nginx/reverse-proxy
-    ports:
-      - "80:80"
     networks:
       - elastic
     logging: *default-logging
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.nginx.loadbalancer.server.port=80
+      - traefik.http.routers.nginx.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.nginx.entrypoints=web
     volumes:
       # Static file service
       - thumbnails_dir:/media/thumbnails
@@ -201,10 +204,10 @@ services:
       - traefik.enable=true
       - traefik.http.services.cvat.loadbalancer.server.port=8080
       - traefik.http.routers.cvat.rule=Host(`${CVAT_HOST:-localhost}`) &&
-          PathPrefix(`/annotation/api/`, `/annotation/git/`, `/annotation/opencv/`, `/annotation/analytics/`, `/annotation/static/`, `/annotation/admin`, `/annotation/documentation/`, `/annotation/django-rq`)
+          PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
       - traefik.http.routers.cvat.entrypoints=web
       - traefik.http.routers.cvat.middlewares=add-cvat
-      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/annotation
+      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/cvat-annotation
       - traefik.http.middlewares.add-cvat.stripprefix.forceSlash=true
     volumes:
       - cvat_data:/home/django/data
@@ -215,17 +218,18 @@ services:
 
   cvat_ui:
     container_name: weedai_cvat_ui
-    image: openvino/cvat_ui
+    image: cvat_cvat_ui
     restart: always
     depends_on:
       - cvat
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat-ui.loadbalancer.server.port=80
-      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`) &&
+          PathPrefix(`/cvat-annotation`, `/cvat-ui`)
       - traefik.http.routers.cvat-ui.entrypoints=web
       - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui
-      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/annotation
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/cvat-annotation
       - traefik.http.middlewares.add-cvat-ui.stripprefix.forceSlash=true
     networks:
       - elastic
@@ -235,19 +239,19 @@ services:
     container_name: weedai_traefik
     restart: always
     command:
-      - "--providers.docker.exposedByDefault=false"
+      - "--providers.docker.exposedByDefault=true"
       - "--providers.docker.network=elastic"
-      - "--entryPoints.web.address=:8080"
+      - "--entryPoints.web.address=:80"
     # Uncomment to get Traefik dashboard
-    #   - "--entryPoints.dashboard.address=:8090"
-    #   - "--api.dashboard=true"
-    # labels:
-    #   - traefik.enable=true
-    #   - traefik.http.routers.dashboard.entrypoints=dashboard
-    #   - traefik.http.routers.dashboard.service=api@internal
-    #   - traefik.http.routers.dashboard.rule=Host(`${CVAT_HOST:-localhost}`)
+      - "--entryPoints.dashboard.address=:8090"
+      - "--api.dashboard=true"
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.dashboard.entrypoints=dashboard
+      - traefik.http.routers.dashboard.service=api@internal
+      - traefik.http.routers.dashboard.rule=Host(`${CVAT_HOST:-localhost}`)
     ports:
-      - 8080:8080
+      - 80:80
       - 8090:8090
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/search/docker-compose-dev.yml
+++ b/search/docker-compose-dev.yml
@@ -60,6 +60,7 @@ services:
       - repository_dir:/code/repository
       - upload_dir:/code/upload
       - download_dir:/code/download
+      - mystatic_dir:/code/mystatic
     ports:
       - "8000:8000"
     networks:
@@ -200,6 +201,8 @@ services:
       CVAT_REDIS_HOST: 'cvat_redis'
       CVAT_POSTGRES_HOST: 'cvat_db'
       ADAPTIVE_AUTO_ANNOTATION: 'false'
+    ports:
+      - "8080:8080"
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat.loadbalancer.server.port=8080

--- a/search/docker-compose-dev.yml
+++ b/search/docker-compose-dev.yml
@@ -20,7 +20,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.nginx.loadbalancer.server.port=80
-      - traefik.http.routers.nginx.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`)
+      - traefik.http.routers.nginx.rule=Host(`${HTTP_HOST:-localhost}`)
       - traefik.http.routers.nginx.entrypoints=web
     volumes:
       # Static file service
@@ -203,7 +203,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat.loadbalancer.server.port=8080
-      - traefik.http.routers.cvat.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`) &&
+      - traefik.http.routers.cvat.rule=Host(`${HTTP_HOST:-localhost}`) &&
           PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
       - traefik.http.routers.cvat.entrypoints=web
       - traefik.http.routers.cvat.middlewares=add-cvat
@@ -225,7 +225,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat-ui.loadbalancer.server.port=80
-      - traefik.http.routers.cvat-ui.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`) &&
+      - traefik.http.routers.cvat-ui.rule=Host(`${HTTP_HOST:-localhost}`) &&
           PathPrefix(`/cvat-annotation`, `/cvat-ui`)
       - traefik.http.routers.cvat-ui.entrypoints=web
       - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -15,11 +15,6 @@ services:
     restart: always
     logging:
       driver: "json-file"
-    labels:
-      - traefik.enable=true
-      - traefik.http.services.nginx.loadbalancer.server.port=80
-      - traefik.http.routers.nginx.rule=Host(`${CVAT_HOST:-localhost}`)
-      - traefik.http.routers.nginx.entrypoints=web
     volumes:
       # Static file service
       - thumbnails_dir:/media/thumbnails
@@ -205,96 +200,6 @@ services:
     logging:
       driver: "json-file"
     restart: always
-
-  cvat_db:
-    container_name: weedai_cvat_db
-    image: postgres:10-alpine
-    restart: always
-    environment:
-      POSTGRES_USER: root
-      POSTGRES_DB: cvat
-      POSTGRES_HOST_AUTH_METHOD: trust
-    volumes:
-      - cvat_db:/var/lib/postgresql/data
-    networks:
-      - elastic
-
-  cvat_redis:
-    container_name: weedai_cvat_redis
-    image: redis:4.0-alpine
-    restart: always
-    networks:
-      - elastic
-
-  cvat:
-    container_name: weedai_cvat
-    image: openvino/cvat_server
-    restart: always
-    depends_on:
-      - cvat_redis
-      - cvat_db
-    environment:
-      DJANGO_MODWSGI_EXTRA_ARGS: ''
-      ALLOWED_HOSTS: '*'
-      CVAT_REDIS_HOST: 'cvat_redis'
-      CVAT_POSTGRES_HOST: 'cvat_db'
-      ADAPTIVE_AUTO_ANNOTATION: 'false'
-    labels:
-      - traefik.enable=true
-      - traefik.http.services.cvat.loadbalancer.server.port=8080
-      - traefik.http.routers.cvat.rule=Host(`${CVAT_HOST:-localhost}`) &&
-          PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
-      - traefik.http.routers.cvat.entrypoints=web
-      - traefik.http.routers.cvat.middlewares=add-cvat
-      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/cvat-annotation
-      - traefik.http.middlewares.add-cvat.stripprefix.forceSlash=true
-    volumes:
-      - cvat_data:/home/django/data
-      - cvat_keys:/home/django/keys
-      - cvat_logs:/home/django/logs
-    networks:
-      - elastic
-
-  cvat_ui:
-    container_name: weedai_cvat_ui
-    image: cvat_cvat_ui
-    restart: always
-    depends_on:
-      - cvat
-    labels:
-      - traefik.enable=true
-      - traefik.http.services.cvat-ui.loadbalancer.server.port=80
-      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`) &&
-          PathPrefix(`/cvat-annotation`, `/cvat-ui`)
-      - traefik.http.routers.cvat-ui.entrypoints=web
-      - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui
-      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/cvat-annotation
-      - traefik.http.middlewares.add-cvat-ui.stripprefix.forceSlash=true
-    networks:
-      - elastic
-
-  traefik:
-    image: traefik:v2.4
-    container_name: weedai_traefik
-    restart: always
-    command:
-      - "--providers.docker.exposedByDefault=false"
-      - "--providers.docker.network=elastic"
-      - "--entryPoints.web.address=:80"
-    # Uncomment to get Traefik dashboard
-    #   - "--entryPoints.dashboard.address=:8090"
-    #   - "--api.dashboard=true"
-    # labels:
-    #   - traefik.enable=true
-    #   - traefik.http.routers.dashboard.entrypoints=dashboard
-    #   - traefik.http.routers.dashboard.service=api@internal
-    #   - traefik.http.routers.dashboard.rule=Host(`${CVAT_HOST:-localhost}`)
-    ports:
-      - 80:80
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    networks:
-      - elastic
 
 networks:
   elastic:

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -8,8 +8,6 @@ services:
         - django
     build:
         context: ./nginx/reverse-proxy
-    ports:
-      - "80:80"
     networks:
       - elastic
     restart: always

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -201,6 +201,96 @@ services:
       driver: "json-file"
     restart: always
 
+  cvat_db:
+    container_name: weedai_cvat_db
+    image: postgres:10-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_DB: cvat
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - cvat_db:/var/lib/postgresql/data
+    networks:
+      - elastic
+
+  cvat_redis:
+    container_name: weedai_cvat_redis
+    image: redis:4.0-alpine
+    restart: always
+    networks:
+      - elastic
+
+  cvat:
+    container_name: weedai_cvat
+    image: openvino/cvat_server
+    restart: always
+    depends_on:
+      - cvat_redis
+      - cvat_db
+    environment:
+      DJANGO_MODWSGI_EXTRA_ARGS: ''
+      ALLOWED_HOSTS: '*'
+      CVAT_REDIS_HOST: 'cvat_redis'
+      CVAT_POSTGRES_HOST: 'cvat_db'
+      ADAPTIVE_AUTO_ANNOTATION: 'false'
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.cvat.loadbalancer.server.port=8080
+      - traefik.http.routers.cvat.rule=Host(`${CVAT_HOST:-localhost}`) &&
+          PathPrefix(`/annotation/api/`, `/annotation/git/`, `/annotation/opencv/`, `/annotation/analytics/`, `/annotation/static/`, `/annotation/admin`, `/annotation/documentation/`, `/annotation/django-rq`)
+      - traefik.http.routers.cvat.entrypoints=web
+      - traefik.http.routers.cvat.middlewares=add-cvat
+      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/annotation
+      - traefik.http.middlewares.add-cvat.stripprefix.forceSlash=true
+    volumes:
+      - cvat_data:/home/django/data
+      - cvat_keys:/home/django/keys
+      - cvat_logs:/home/django/logs
+    networks:
+      - elastic
+
+  cvat_ui:
+    container_name: weedai_cvat_ui
+    image: openvino/cvat_ui
+    restart: always
+    depends_on:
+      - cvat
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.cvat-ui.loadbalancer.server.port=80
+      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.cvat-ui.entrypoints=web
+      - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/annotation
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.forceSlash=true
+    networks:
+      - elastic
+
+  traefik:
+    image: traefik:v2.4
+    container_name: weedai_traefik
+    restart: always
+    command:
+      - "--providers.docker.exposedByDefault=false"
+      - "--providers.docker.network=elastic"
+      - "--entryPoints.web.address=:8080"
+    # Uncomment to get Traefik dashboard
+    #   - "--entryPoints.dashboard.address=:8090"
+    #   - "--api.dashboard=true"
+    # labels:
+    #   - traefik.enable=true
+    #   - traefik.http.routers.dashboard.entrypoints=dashboard
+    #   - traefik.http.routers.dashboard.service=api@internal
+    #   - traefik.http.routers.dashboard.rule=Host(`${CVAT_HOST:-localhost}`)
+    ports:
+      - 8080:8080
+      - 8090:8090
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - elastic
+
 networks:
   elastic:
     driver: bridge
@@ -220,3 +310,7 @@ volumes:
     driver: local
   mystatic_dir:
     driver: local
+  cvat_db:
+  cvat_data:
+  cvat_keys:
+  cvat_logs:

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -15,6 +15,11 @@ services:
     restart: always
     logging:
       driver: "json-file"
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.nginx.loadbalancer.server.port=80
+      - traefik.http.routers.nginx.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.nginx.entrypoints=web
     volumes:
       # Static file service
       - thumbnails_dir:/media/thumbnails
@@ -200,6 +205,96 @@ services:
     logging:
       driver: "json-file"
     restart: always
+
+  cvat_db:
+    container_name: weedai_cvat_db
+    image: postgres:10-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_DB: cvat
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - cvat_db:/var/lib/postgresql/data
+    networks:
+      - elastic
+
+  cvat_redis:
+    container_name: weedai_cvat_redis
+    image: redis:4.0-alpine
+    restart: always
+    networks:
+      - elastic
+
+  cvat:
+    container_name: weedai_cvat
+    image: openvino/cvat_server
+    restart: always
+    depends_on:
+      - cvat_redis
+      - cvat_db
+    environment:
+      DJANGO_MODWSGI_EXTRA_ARGS: ''
+      ALLOWED_HOSTS: '*'
+      CVAT_REDIS_HOST: 'cvat_redis'
+      CVAT_POSTGRES_HOST: 'cvat_db'
+      ADAPTIVE_AUTO_ANNOTATION: 'false'
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.cvat.loadbalancer.server.port=8080
+      - traefik.http.routers.cvat.rule=Host(`${CVAT_HOST:-localhost}`) &&
+          PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
+      - traefik.http.routers.cvat.entrypoints=web
+      - traefik.http.routers.cvat.middlewares=add-cvat
+      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/cvat-annotation
+      - traefik.http.middlewares.add-cvat.stripprefix.forceSlash=true
+    volumes:
+      - cvat_data:/home/django/data
+      - cvat_keys:/home/django/keys
+      - cvat_logs:/home/django/logs
+    networks:
+      - elastic
+
+  cvat_ui:
+    container_name: weedai_cvat_ui
+    image: cvat_cvat_ui
+    restart: always
+    depends_on:
+      - cvat
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.cvat-ui.loadbalancer.server.port=80
+      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`) &&
+          PathPrefix(`/cvat-annotation`, `/cvat-ui`)
+      - traefik.http.routers.cvat-ui.entrypoints=web
+      - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/cvat-annotation
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.forceSlash=true
+    networks:
+      - elastic
+
+  traefik:
+    image: traefik:v2.4
+    container_name: weedai_traefik
+    restart: always
+    command:
+      - "--providers.docker.exposedByDefault=false"
+      - "--providers.docker.network=elastic"
+      - "--entryPoints.web.address=:80"
+    # Uncomment to get Traefik dashboard
+    #   - "--entryPoints.dashboard.address=:8090"
+    #   - "--api.dashboard=true"
+    # labels:
+    #   - traefik.enable=true
+    #   - traefik.http.routers.dashboard.entrypoints=dashboard
+    #   - traefik.http.routers.dashboard.service=api@internal
+    #   - traefik.http.routers.dashboard.rule=Host(`${CVAT_HOST:-localhost}`)
+    ports:
+      - 80:80
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - elastic
 
 networks:
   elastic:

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -241,10 +241,10 @@ services:
       - traefik.enable=true
       - traefik.http.services.cvat.loadbalancer.server.port=8080
       - traefik.http.routers.cvat.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`) &&
-          PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
+          PathPrefix(`${CVAT_BASEPATH}/api/`, `${CVAT_BASEPATH}/git/`, `${CVAT_BASEPATH}/opencv/`, `${CVAT_BASEPATH}/analytics/`, `${CVAT_BASEPATH}/static/`, `${CVAT_BASEPATH}/admin`, `${CVAT_BASEPATH}/documentation/`, `${CVAT_BASEPATH}/django-rq`)
       - traefik.http.routers.cvat.entrypoints=web
       - traefik.http.routers.cvat.middlewares=add-cvat
-      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/cvat-annotation
+      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=${CVAT_BASEPATH}
       - traefik.http.middlewares.add-cvat.stripprefix.forceSlash=true
     volumes:
       - cvat_data:/home/django/data
@@ -263,10 +263,10 @@ services:
       - traefik.enable=true
       - traefik.http.services.cvat-ui.loadbalancer.server.port=80
       - traefik.http.routers.cvat-ui.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`) &&
-          PathPrefix(`/cvat-annotation`, `/cvat-ui`)
+          PathPrefix(`${CVAT_BASEPATH}`, `/cvat-ui`)
       - traefik.http.routers.cvat-ui.entrypoints=web
       - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui
-      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/cvat-annotation
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=${CVAT_BASEPATH}
       - traefik.http.middlewares.add-cvat-ui.stripprefix.forceSlash=true
     networks:
       - elastic

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -15,6 +15,11 @@ services:
     restart: always
     logging:
       driver: "json-file"
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.nginx.loadbalancer.server.port=80
+      - traefik.http.routers.nginx.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.nginx.entrypoints=web
     volumes:
       # Static file service
       - thumbnails_dir:/media/thumbnails
@@ -238,10 +243,10 @@ services:
       - traefik.enable=true
       - traefik.http.services.cvat.loadbalancer.server.port=8080
       - traefik.http.routers.cvat.rule=Host(`${CVAT_HOST:-localhost}`) &&
-          PathPrefix(`/annotation/api/`, `/annotation/git/`, `/annotation/opencv/`, `/annotation/analytics/`, `/annotation/static/`, `/annotation/admin`, `/annotation/documentation/`, `/annotation/django-rq`)
+          PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
       - traefik.http.routers.cvat.entrypoints=web
       - traefik.http.routers.cvat.middlewares=add-cvat
-      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/annotation
+      - traefik.http.middlewares.add-cvat.stripprefix.prefixes=/cvat-annotation
       - traefik.http.middlewares.add-cvat.stripprefix.forceSlash=true
     volumes:
       - cvat_data:/home/django/data
@@ -252,17 +257,18 @@ services:
 
   cvat_ui:
     container_name: weedai_cvat_ui
-    image: openvino/cvat_ui
+    image: cvat_cvat_ui
     restart: always
     depends_on:
       - cvat
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat-ui.loadbalancer.server.port=80
-      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`) &&
+          PathPrefix(`/cvat-annotation`, `/cvat-ui`)
       - traefik.http.routers.cvat-ui.entrypoints=web
       - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui
-      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/annotation
+      - traefik.http.middlewares.add-cvat-ui.stripprefix.prefixes=/cvat-annotation
       - traefik.http.middlewares.add-cvat-ui.stripprefix.forceSlash=true
     networks:
       - elastic
@@ -274,7 +280,7 @@ services:
     command:
       - "--providers.docker.exposedByDefault=false"
       - "--providers.docker.network=elastic"
-      - "--entryPoints.web.address=:8080"
+      - "--entryPoints.web.address=:80"
     # Uncomment to get Traefik dashboard
     #   - "--entryPoints.dashboard.address=:8090"
     #   - "--api.dashboard=true"
@@ -284,8 +290,7 @@ services:
     #   - traefik.http.routers.dashboard.service=api@internal
     #   - traefik.http.routers.dashboard.rule=Host(`${CVAT_HOST:-localhost}`)
     ports:
-      - 8080:8080
-      - 8090:8090
+      - 80:80
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.nginx.loadbalancer.server.port=80
-      - traefik.http.routers.nginx.rule=Host(`${CVAT_HOST:-localhost}`)
+      - traefik.http.routers.nginx.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`)
       - traefik.http.routers.nginx.entrypoints=web
     volumes:
       # Static file service
@@ -240,7 +240,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat.loadbalancer.server.port=8080
-      - traefik.http.routers.cvat.rule=Host(`${CVAT_HOST:-localhost}`) &&
+      - traefik.http.routers.cvat.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`) &&
           PathPrefix(`/cvat-annotation/api/`, `/cvat-annotation/git/`, `/cvat-annotation/opencv/`, `/cvat-annotation/analytics/`, `/cvat-annotation/static/`, `/cvat-annotation/admin`, `/cvat-annotation/documentation/`, `/cvat-annotation/django-rq`)
       - traefik.http.routers.cvat.entrypoints=web
       - traefik.http.routers.cvat.middlewares=add-cvat
@@ -262,7 +262,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.cvat-ui.loadbalancer.server.port=80
-      - traefik.http.routers.cvat-ui.rule=Host(`${CVAT_HOST:-localhost}`) &&
+      - traefik.http.routers.cvat-ui.rule=Host(`${HTTP_HOST:-localhost}`,`${HTTPS_HOST}`) &&
           PathPrefix(`/cvat-annotation`, `/cvat-ui`)
       - traefik.http.routers.cvat-ui.entrypoints=web
       - traefik.http.routers.cvat-ui.middlewares=add-cvat-ui

--- a/search/nginx/reverse-proxy/nginx.conf
+++ b/search/nginx/reverse-proxy/nginx.conf
@@ -44,11 +44,6 @@ http {
             proxy_pass              http://django:8000/sitemap.xml;
         }
 
-        location /cvat/ {
-            rewrite ^/cvat/(.*) /$1 break;
-            proxy_pass              http://traefik:8080/;
-        }
-
         location /code/download/ {
             alias /media/download/;
         }

--- a/search/nginx/reverse-proxy/nginx.conf
+++ b/search/nginx/reverse-proxy/nginx.conf
@@ -44,6 +44,11 @@ http {
             proxy_pass              http://django:8000/sitemap.xml;
         }
 
+        location /cvat/ {
+            rewrite ^/cvat/(.*) /$1 break;
+            proxy_pass              http://traefik:8080/;
+        }
+
         location /code/download/ {
             alias /media/download/;
         }


### PR DESCRIPTION
Clone from my forked version https://github.com/Weed-AI/cvat/tree/usyd
Build cvat-ui using `docker-compose build --no-cache cvat_ui`
Run `COMPOSE_HTTP_TIMEOUT=500 docker-compose -f docker-compose-dev.yml up` to start Weed-AI
Go to localhost/cvat-annotation to use cvat