### PR TITLE
Allow validate to run without strict reference checking

### DIFF
--- a/weedcoco/tests/test_validation.py
+++ b/weedcoco/tests/test_validation.py
@@ -230,6 +230,7 @@ def _make_unreferenced(weedcoco, section, new_id=1000):
 def test_id_not_referenced(func, bad_weedcoco):
     with pytest.raises(ValidationError, match="is unreferenced"):
         func(bad_weedcoco)
+    func(bad_weedcoco, require_reference=())  # no reference validation
 
 
 def _weedcoco_to_coco(weedcoco):

--- a/weedcoco/validation.py
+++ b/weedcoco/validation.py
@@ -181,11 +181,16 @@ def validate_image_sizes(weedcoco, images_root):
     # TODO
 
 
-def validate(weedcoco, images_root=None, schema="weedcoco"):
+def validate(
+    weedcoco,
+    images_root=None,
+    schema="weedcoco",
+    require_reference=("image", "agcontext"),
+):
     if hasattr(weedcoco, "read"):
         weedcoco = json.load(weedcoco)
     validate_json(weedcoco, schema=schema)
-    validate_references(weedcoco)
+    validate_references(weedcoco, require_reference=require_reference)
     validate_coordinates(weedcoco)
     if images_root is not None:
         validate_image_sizes(weedcoco, images_root)


### PR DESCRIPTION
Passes a require_reference parameter to the validate_reference function. Defaults to ("agcontext", "images").

For issue #595 