### PR TITLE
Test fix: ensure dialog has proceeded to next step

### DIFF
--- a/search/cypress/integration/weedai_upload.js
+++ b/search/cypress/integration/weedai_upload.js
@@ -1,10 +1,22 @@
-
 const safeSetForm = () => {
-	cy.wait(1000)
-	// hack needed due to textarea risizing upredictably
-	cy.clickText(/JSON data/)
-	cy.focused().blur()
-	cy.clickText(/^Set Form$/)
+    cy.wait(1000)
+    // hack needed due to textarea risizing upredictably
+    cy.clickText(/JSON data/)
+    cy.focused().blur()
+    cy.clickText(/^Set Form$/)
+}
+
+const setAgAndMeta = () => {
+    cy.clickText(/^Upload and Download Form Contents$/)
+    cy.get('.dzu-input').attachFile('test_coco/agcontext.json')
+    safeSetForm()
+    cy.clickText(/^Next$/)
+
+    cy.findByText(/Dataset Name/i) // Ensure we have proceeded to metadata
+    cy.clickText(/^Upload and Download Form Contents$/)
+    cy.get('.dzu-input').attachFile('test_coco/metadata.json')
+    safeSetForm()
+    cy.clickText(/^Next$/)
 }
 
 describe('overall upload workflow', () => {
@@ -39,7 +51,6 @@ describe('overall upload workflow', () => {
         cy.clickText(/^Submit$/)
     })
 
-
     it('Test Coco Upload', () => {
         cy.findByText(/^Select annotation format$/).click()
         cy.findByText("COCO").click()
@@ -50,14 +61,7 @@ describe('overall upload workflow', () => {
         cy.findByDisplayValue(/^UNSPECIFIED$/).click().clear().type('rapistrum rugosum{enter}')
         cy.clickText(/^Apply$/)
         cy.clickText(/^Next$/)
-        cy.clickText(/^Upload and Download Form Contents$/)
-        cy.get('.dzu-input').attachFile('test_coco/agcontext.json')
-        safeSetForm()
-        cy.clickText(/^Next$/)
-        cy.clickText(/^Upload and Download Form Contents$/)
-        cy.get('.dzu-input').attachFile('test_coco/metadata.json')
-        safeSetForm()
-        cy.clickText(/^Next$/)
+        setAgAndMeta()
         cy.get('div.fileContainer > input').attachFile('test_coco/images/002_image.png')
         cy.clickText(/^Submit$/)
     })
@@ -72,14 +76,7 @@ describe('overall upload workflow', () => {
         cy.clickText(/^Next$/)
         cy.clickText(/^Apply$/)
         cy.clickText(/^Next$/)
-        cy.clickText(/^Upload and Download Form Contents$/)
-        cy.get('.dzu-input').attachFile('test_voc/agcontext.json')
-        safeSetForm()
-        cy.clickText(/^Next$/)
-        cy.clickText(/^Upload and Download Form Contents$/)
-        cy.get('.dzu-input').attachFile('test_voc/metadata.json')
-        safeSetForm()
-        cy.clickText(/^Next$/)
+        setAgAndMeta()
         cy.get('div.fileContainer > input').attachFile('test_voc/images/resizeC1_PLOT_20190728_175852.jpg')
         cy.get('div.fileContainer > input').attachFile('test_voc/images/resizeC1_PLOT_20190728_180135.jpg')
         cy.clickText(/^Submit$/)

--- a/search/cypress/integration/weedai_upload.js
+++ b/search/cypress/integration/weedai_upload.js
@@ -1,24 +1,3 @@
-const safeSetForm = () => {
-    cy.wait(1000)
-    // hack needed due to textarea risizing upredictably
-    cy.clickText(/JSON data/)
-    cy.focused().blur()
-    cy.clickText(/^Set Form$/)
-}
-
-const setAgAndMeta = () => {
-    cy.clickText(/^Upload and Download Form Contents$/)
-    cy.get('.dzu-input').attachFile('test_coco/agcontext.json')
-    safeSetForm()
-    cy.clickText(/^Next$/)
-
-    cy.findByText(/Dataset Name/i) // Ensure we have proceeded to metadata
-    cy.clickText(/^Upload and Download Form Contents$/)
-    cy.get('.dzu-input').attachFile('test_coco/metadata.json')
-    safeSetForm()
-    cy.clickText(/^Next$/)
-}
-
 describe('overall upload workflow', () => {
 
     beforeEach(() => {
@@ -61,7 +40,7 @@ describe('overall upload workflow', () => {
         cy.findByDisplayValue(/^UNSPECIFIED$/).click().clear().type('rapistrum rugosum{enter}')
         cy.clickText(/^Apply$/)
         cy.clickText(/^Next$/)
-        setAgAndMeta()
+        cy.setAgAndMeta()
         cy.get('div.fileContainer > input').attachFile('test_coco/images/002_image.png')
         cy.clickText(/^Submit$/)
     })
@@ -76,7 +55,7 @@ describe('overall upload workflow', () => {
         cy.clickText(/^Next$/)
         cy.clickText(/^Apply$/)
         cy.clickText(/^Next$/)
-        setAgAndMeta()
+        cy.setAgAndMeta()
         cy.get('div.fileContainer > input').attachFile('test_voc/images/resizeC1_PLOT_20190728_175852.jpg')
         cy.get('div.fileContainer > input').attachFile('test_voc/images/resizeC1_PLOT_20190728_180135.jpg')
         cy.clickText(/^Submit$/)

--- a/search/cypress/support/commands.js
+++ b/search/cypress/support/commands.js
@@ -54,3 +54,24 @@ Cypress.Commands.add('login', (username, password) => {
 Cypress.Commands.add('clickText', text => {
     cy.findAllByText(text).should('have.length', 1).click()
 })
+
+Cypress.Commands.add('safeSetForm', () => {
+    cy.wait(1000)
+    // hack needed due to textarea risizing upredictably
+    cy.clickText(/JSON data/)
+    cy.focused().blur()
+    cy.clickText(/^Set Form$/)
+})
+
+Cypress.Commands.add('setAgAndMeta', () => {
+    cy.clickText(/^Upload and Download Form Contents$/)
+    cy.get('.dzu-input').attachFile('test_coco/agcontext.json')
+    cy.safeSetForm()
+    cy.clickText(/^Next$/)
+
+    cy.findByText(/Dataset Name/i) // Ensure we have proceeded to metadata
+    cy.clickText(/^Upload and Download Form Contents$/)
+    cy.get('.dzu-input').attachFile('test_coco/metadata.json')
+    cy.safeSetForm()
+    cy.clickText(/^Next$/)
+})


### PR DESCRIPTION
When it is slow to save agcontext, the test may click the 'upload form contents' button (which should be disabled after next is pressed, but that's a separate issue)

So glad to finally fix the mysterious issue plaguing #593 (whether or not we want to go ahead with merging that one)