### PR TITLE
Allow arbitrary subcategorisation of valid categories by dataset contributors

### DIFF
--- a/search/cypress/integration/weedai_upload.js
+++ b/search/cypress/integration/weedai_upload.js
@@ -38,7 +38,10 @@ describe('overall upload workflow', () => {
         cy.clickText(/^Next$/)
         cy.get('.dzu-input').attachFile('test_coco/coco.json')
         cy.clickText(/^Next$/)
+        cy.clickText(/crop: daucus/)  // expand accordion
         cy.findByText("crop").type('weed{enter}')
+        cy.clickText(/crop: daucus/)  // collapse accordion
+        cy.clickText(/weed: UNSPECIFIED/)  // expand accordion
         cy.findByDisplayValue(/^UNSPECIFIED$/).click().clear().type('rapistrum rugosum{enter}')
         cy.clickText(/^Apply$/)
         cy.clickText(/^Next$/)

--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -29,7 +29,7 @@ from weedid.utils import (
     add_agcontexts,
     add_metadata,
     validate_email_format,
-    parse_category_name,
+    parse_category_for_mapper,
 )
 from weedid.notification import review_notification
 from weedid.models import Dataset, WeedidUser
@@ -99,7 +99,8 @@ def upload(request):
         for image_reference in weedcoco_json["images"]:
             images.append(image_reference["file_name"].split("/")[-1])
         categories = [
-            parse_category_name(category) for category in weedcoco_json["categories"]
+            parse_category_for_mapper(category)
+            for category in weedcoco_json["categories"]
         ]
         upload_dir, upload_id = setup_upload_dir(os.path.join(UPLOAD_DIR, str(user.id)))
         store_tmp_weedcoco(weedcoco_json, upload_dir)
@@ -207,7 +208,8 @@ class CustomUploader:
             for image_reference in coco_json["images"]:
                 images.append(image_reference["file_name"].split("/")[-1])
             categories = [
-                parse_category_name(category) for category in coco_json["categories"]
+                parse_category_for_mapper(category)
+                for category in coco_json["categories"]
             ]
             upload_dir, upload_id = setup_upload_dir(
                 os.path.join(UPLOAD_DIR, str(user.id))

--- a/search/src/Common/weedcocoUtil.js
+++ b/search/src/Common/weedcocoUtil.js
@@ -1,7 +1,8 @@
 export const parseCategoryName = (categoryName) => {
-  const groups = categoryName.match(/^([^:]*): (.*)/);
-  console.log('*', groups)
-  return groups === null ? {role: categoryName} : {role: groups[1], taxon: groups[2]};
+  const groups = categoryName.match(/^([^:]*): ([^\(]*)(?: \((.*?)\))?/);
+  return groups === null ? {role: categoryName} : {role: groups[1], taxon: groups[2], subcategory: groups[3]};
 }
 
-
+export const formatCategoryName = ({ role, taxon, subcategory }) => {
+  return `${role || '??'}: ${taxon || '??'}${subcategory ? " (" + subcategory + ')' : ""}`
+}

--- a/search/src/Components/upload/uploader_category_mapper.js
+++ b/search/src/Components/upload/uploader_category_mapper.js
@@ -6,6 +6,11 @@ import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
+import Accordion from '@material-ui/core/Accordion';
+import Typography from '@material-ui/core/Typography';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import cloneDeep from 'lodash/cloneDeep';
 
 
@@ -14,8 +19,12 @@ const useStyles = (theme) => ({
         marginLeft: '2.5em'
     },
     row: {
-        display: 'flex',
-        alignItems: 'baseline'
+        backgroundColor: theme.palette.grey[50],
+    },
+    categoryList: {
+        overflow: "scroll",
+        maxHeight: "15em",
+        margin: theme.spacing(2),
     },
     incomplete: {
         color: 'red'
@@ -35,9 +44,36 @@ const useStyles = (theme) => ({
         height: '1.2em',
         width: '1.2em',
         borderRadius: '50%',
-        margin: '1em'
+        marginRight: "1em",
     }
 });
+
+const isComplete = (category) => (category.role && category.scientific_name);
+
+const CategoryEditor = ({ category, classes, isColor, changeRole, changeSciName }) => {
+    const complete = isComplete(category);
+    return (<Accordion className={complete ? classes.row : `${classes.row} ${classes.incomplete}`} defaultExpanded={!complete}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            {isColor ? <div className={classes.color} style={{backgroundColor: '#' + category.name}}></div> : []}
+            <Typography>{isColor ? '#' : ''}{category.name}</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+            <FormControl fullWidth={true} className={classes.formControl}>
+                <InputLabel id="category">Role</InputLabel>
+                <Select
+                labelId="category"
+                id="category"
+                value={category.role}
+                onChange={e => {changeRole(e)}}
+                >
+                    <MenuItem value={"crop"}>crop</MenuItem>
+                    <MenuItem value={"weed"}>weed</MenuItem>
+                </Select>
+            </FormControl>
+            <TextField fullWidth={true} className={classes.sci_name} label="Scientific name or UNSPECIFIED" value={category.scientific_name} onChange={e => {e.persist(); changeSciName(e)}}/>
+        </AccordionDetails>
+    </Accordion>);
+}
 
 class CategoryMapper extends React.Component {
     
@@ -72,36 +108,22 @@ class CategoryMapper extends React.Component {
     render() {
         const { classes } = this.props;
         const nCategories = this.state.categories.length;
-        const nComplete = this.state.categories.filter(category => category.role && category.scientific_name).length;
+        const nComplete = this.state.categories.filter(isComplete).length;
         return (
             <React.Fragment>
                 <p className={classes.summary}>{nCategories - nComplete} of {nCategories} {nCategories != 1 ? 'categories' : 'category'} need mapping to weedcoco categories</p>
-                <ol>
+                <div className={classes.categoryList}>
                     {
                         this.state.categories.map((category, index) => {
-                            return (
-                                <li className={category.role && category.name ? classes.row : `${classes.row} ${classes.incomplete}`}>
-                                    {/^[0-9A-Fa-f]{6}$/i.test(category.name) ? <div className={classes.color} style={{backgroundColor: '#' + category.name}}></div> : <p>{category.name}</p>}
-                                    <p className={classes.text_field}> is a</p>
-                                    <FormControl className={classes.formControl}>
-                                        <InputLabel id="category">Role</InputLabel>
-                                        <Select
-                                        labelId="category"
-                                        id="category"
-                                        value={category.role}
-                                        onChange={e => {this.changeRole(e, index)}}
-                                        >
-                                            <MenuItem value={"crop"}>crop</MenuItem>
-                                            <MenuItem value={"weed"}>weed</MenuItem>
-                                        </Select>
-                                    </FormControl>
-                                    <p className={classes.text_field}>of type</p>
-                                    <TextField className={classes.sci_name} label="Scientific name or UNSPECIFIED" value={category.scientific_name} onChange={e => {e.persist(); this.changeSciName(e, index)}}/>
-                                </li>
-                            )
+                            return <CategoryEditor
+                                key={index} classes={classes}
+                                category={category} isColor={/^[0-9A-Fa-f]{6}$/i.test(category.name)}
+                                changeRole={(e) => this.changeRole(e, index)}
+                                changeSciName={(e) => this.changeSciName(e, index)}
+                            />
                         })
                     }
-                </ol>
+                </div>
                 <Button variant="contained"
                         color="primary"
                         className={classes.applyButton}

--- a/weedcoco/schema/Category.yaml
+++ b/weedcoco/schema/Category.yaml
@@ -7,12 +7,15 @@ allOf:
       name:
         type: string
         format: weedcoco_category
-        pattern: "^((crop|weed): ([a-z][a-z. ]+|UNSPECIFIED)|crop|weed|none)$"
+        pattern: "^((crop|weed): ([a-z][a-z. ]+|UNSPECIFIED)|crop|weed|none)(?: \\([^)]+\\))?$"
         description: |-
           A category for an annotation, consisting of an agricultural role and
-          optionally a biological name, separated by ": ". Currently allowed
+          optionally a scientific name, separated by ": ". Currently allowed
           agricultural roles are "weed" and "crop".  The "none" category may be
           used to indicate that no weed or crop is identified in the image.
+
+          An arbitrary subcategory may also be appended in parentheses. This may be used
+          to indicate, for instance, the growth stage or plant part being annotated.
 
           Annotations should be labelled with the most specific category possible,
           usually "weed: <species name>".

--- a/weedcoco/tests/index/test_indexing.py
+++ b/weedcoco/tests/index/test_indexing.py
@@ -63,8 +63,13 @@ def test_annotation_and_category():
             },
         },
         3: {
-            "name": "weed: lolium perenne",
-            "taxo_names": {"weed: lolium perenne", "weed: poaceae", "weed"},
+            "name": "weed: lolium perenne (growing point)",
+            "taxo_names": {
+                "weed: lolium perenne (growing point)",
+                "weed: lolium perenne",
+                "weed: poaceae",
+                "weed",
+            },
         },
     }
     for entry in indexer.generate_index_entries():

--- a/weedcoco/tests/repo/deposit_data/basic_1/weedcoco.json
+++ b/weedcoco/tests/repo/deposit_data/basic_1/weedcoco.json
@@ -661,7 +661,7 @@
             "id": 2
         },
         {
-            "name": "weed: lolium perenne",
+            "name": "weed: lolium perenne (growing point)",
             "id": 3
         }
     ],

--- a/weedcoco/tests/repo/deposit_data_sample/basic/dataset_1/weedcoco.json
+++ b/weedcoco/tests/repo/deposit_data_sample/basic/dataset_1/weedcoco.json
@@ -661,7 +661,7 @@
             "id": 2
         },
         {
-            "name": "weed: lolium perenne",
+            "name": "weed: lolium perenne (growing point)",
             "id": 3
         }
     ],

--- a/weedcoco/tests/repo/deposit_data_sample/multiple/dataset_1/weedcoco.json
+++ b/weedcoco/tests/repo/deposit_data_sample/multiple/dataset_1/weedcoco.json
@@ -661,7 +661,7 @@
             "id": 2
         },
         {
-            "name": "weed: lolium perenne",
+            "name": "weed: lolium perenne (growing point)",
             "id": 3
         }
     ],

--- a/weedcoco/validation.py
+++ b/weedcoco/validation.py
@@ -12,6 +12,7 @@ from jsonschema.validators import Draft7Validator, RefResolver
 import yaml
 
 from .species_utils import get_eppo_singleton
+from .utils import parse_category_name
 
 SCHEMA_DIR = pathlib.Path(__file__).parent / "schema"
 MAIN_SCHEMAS = {
@@ -54,21 +55,23 @@ def check_plant_taxon_format(value):
 
 @FORMAT_CHECKER.checks("weedcoco_category")
 def check_weedcoco_category_format(value):
-    prefix, colon, taxon = value.partition(": ")
-    if not colon:
+    parsed = parse_category_name(value)
+    if parsed is None:
+        return
+    if not parsed["taxon"]:
         # Category must begin with weed, crop or none
-        return prefix in {"weed", "crop", "none"}
+        return parsed["role"] in {"weed", "crop", "none"}
 
     # Specific category must begin with 'weed:' or 'crop:'
-    if prefix not in {"weed", "crop"}:
+    if parsed["role"] not in {"weed", "crop"}:
         return False
 
-    if taxon == "UNSPECIFIED":
+    if parsed["taxon"] == "UNSPECIFIED":
         # crop: UNSPECIFIED is not a valid category
-        return prefix == "weed"
+        return parsed["role"] == "weed"
 
     # Taxon name should be lowercase in category
-    return check_plant_taxon_format(taxon)
+    return check_plant_taxon_format(parsed["taxon"])
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
@geezacoleman this would allow you to define categories `weed: amaranthus palmeri (BBCH 20)` as distinct from `weed: amaranthus palmeri (BBCH 30)`

With this code, the category mapper becomes a series of accordions (not sure about this UX, but I have negative budget to refine it) with three fields: role, taxon, subcat (optional). The UI becomes much more vertical.

![image](https://user-images.githubusercontent.com/78827/155946753-ec7cdc05-824e-4bc2-9854-c327d8d75c93.png)
