### PR TITLE
Async unpacking of zip files with polling of Celery task

### DIFF
--- a/search/django/weedid/tasks.py
+++ b/search/django/weedid/tasks.py
@@ -3,12 +3,15 @@ import json
 import traceback
 import datetime
 import subprocess
+import tempfile
+from shutil import copy
+from zipfile import ZipFile
 from celery import shared_task
 from weedcoco.repo.deposit import deposit, compress_to_download
 from weedcoco.index.indexing import ElasticSearchIndexer
 from weedcoco.index.thumbnailing import thumbnailing
 from weedid.models import Dataset
-from weedid.utils import make_upload_entity_fields
+from weedid.utils import make_upload_entity_fields, mkdir_safely
 from weedid.notification import upload_notification, review_notification
 from core.settings import (
     THUMBNAILS_DIR,
@@ -218,3 +221,19 @@ def backup_repository_changes(repository_dir=REPOSITORY_DIR, commit_message=None
         ],
         cwd=REPOSITORY_DIR,
     )
+
+
+@shared_task
+def store_tmp_image_from_zip(upload_id, upload_image_zip, image_dir, full_images):
+    if not os.path.isdir(image_dir):
+        mkdir_safely(image_dir)
+    existing_images = os.listdir(image_dir)
+    with tempfile.TemporaryDirectory() as tempdir:
+        ZipFile(upload_image_zip).extractall(tempdir)
+        for dir, _, filenames in os.walk(tempdir):
+            # FIXME: this should reject a zip upload if two filenames are identical
+            for filename in filenames:
+                if filename in full_images and filename not in existing_images:
+                    copy(os.path.join(dir, filename), os.path.join(image_dir, filename))
+    missing_images = list(set(os.listdir(image_dir)))
+    return {"upload_id": upload_id, "missing_images": missing_images}

--- a/search/django/weedid/urls.py
+++ b/search/django/weedid/urls.py
@@ -15,7 +15,9 @@ api_urlpatterns = [
     path("move_mask/", views.MaskUploader.move, name="move_mask"),
     path("upload_image/", views.upload_image, name="upload_image"),
     path("unpack_image_zip/", views.unpack_image_zip, name="unpack_image_zip"),
-    path("check_image_zip/", views.check_image_zip, name="check_image_zip"),
+    path(
+        "check_image_zip/<str:task_id>", views.check_image_zip, name="check_image_zip"
+    ),
     path("update_categories/", views.update_categories, name="update_categories"),
     path("upload_agcontexts/", views.upload_agcontexts, name="upload_agcontexts"),
     path("upload_metadata/", views.upload_metadata, name="upload_metadata"),

--- a/search/django/weedid/urls.py
+++ b/search/django/weedid/urls.py
@@ -15,6 +15,7 @@ api_urlpatterns = [
     path("move_mask/", views.MaskUploader.move, name="move_mask"),
     path("upload_image/", views.upload_image, name="upload_image"),
     path("unpack_image_zip/", views.unpack_image_zip, name="unpack_image_zip"),
+    path("check_image_zip/", views.check_image_zip, name="check_image_zip"),
     path("update_categories/", views.update_categories, name="update_categories"),
     path("upload_agcontexts/", views.upload_agcontexts, name="upload_agcontexts"),
     path("upload_metadata/", views.upload_metadata, name="upload_metadata"),

--- a/search/django/weedid/utils.py
+++ b/search/django/weedid/utils.py
@@ -5,9 +5,6 @@ import re
 from uuid import uuid4
 import smtplib
 from email.message import EmailMessage
-import tempfile
-from zipfile import ZipFile
-from shutil import copy
 from weedcoco.repo.deposit import mkdir_safely
 from weedcoco.utils import set_info, set_licenses
 from weedcoco.stats import WeedCOCOStats
@@ -34,20 +31,6 @@ class OverwriteStorage(FileSystemStorage):
 def store_tmp_image(image, image_dir):
     fs = OverwriteStorage()
     fs.save(os.path.join(image_dir, image.name), image)
-
-
-def store_tmp_image_from_zip(upload_image_zip, image_dir, full_images):
-    if not os.path.isdir(image_dir):
-        mkdir_safely(image_dir)
-    existing_images = os.listdir(image_dir)
-    with tempfile.TemporaryDirectory() as tempdir:
-        ZipFile(upload_image_zip).extractall(tempdir)
-        for dir, _, filenames in os.walk(tempdir):
-            # FIXME: this should reject a zip upload if two filenames are identical
-            for filename in filenames:
-                if filename in full_images and filename not in existing_images:
-                    copy(os.path.join(dir, filename), os.path.join(image_dir, filename))
-    return list(set(os.listdir(image_dir)))
 
 
 def store_tmp_weedcoco(weedcoco, upload_dir):

--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -38,7 +38,7 @@ from weedid.models import Dataset, WeedidUser
 from weedid.notification import review_notification
 from weedid.tasks import (
     submit_upload_task,
-    update_index_and_thumbnails, 
+    update_index_and_thumbnails,
     store_tmp_image_from_zip
 )
 from weedid.utils import (

--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -39,7 +39,7 @@ from weedid.notification import review_notification
 from weedid.tasks import (
     submit_upload_task,
     update_index_and_thumbnails,
-    store_tmp_image_from_zip
+    store_tmp_image_from_zip,
 )
 from weedid.utils import (
     add_agcontexts,

--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -294,8 +294,7 @@ def unpack_image_zip(request):
     return HttpResponse(json.dumps({"task_id": celery_task.id}))
 
 
-def check_image_zip(request):
-    task_id = request.GET["task_id"]
+def check_image_zip(request, task_id):
     result = store_tmp_image_from_zip.AsyncResult(task_id)
     if not result.ready():
         return HttpResponse("wait", status_code=202)

--- a/search/docker-compose-dev.yml
+++ b/search/docker-compose-dev.yml
@@ -51,7 +51,7 @@ services:
       - SEND_EMAIL=${SEND_EMAIL}
       - ENV=DEV
       - TUS_SERVER=http://tus:1080/tus/
-      - DJANGO_LOG_LEVEL=DEBUG
+      - DJANGO_LOG_LEVEL=INFO
     command: python manage.py runserver 0.0.0.0:8000
     entrypoint: /entrypoint.sh
     volumes:

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - repository_dir:/code/repository
       - upload_dir:/code/upload
       - download_dir:/code/download
+      - tus_dir:/code/tus_dir
       - ${GIT_REMOTE_PATH}:/mnt/git_remote
       - ${DVC_REMOTE_PATH}:/mnt/dvc_remote
     depends_on:

--- a/search/src/Components/upload/uploader_zip.js
+++ b/search/src/Components/upload/uploader_zip.js
@@ -46,8 +46,7 @@ const getZipUploadResponse = ({upload_id, images, filename}) => {
             const poll = () => {
                 axios({
                     method: 'get',
-                    url: baseURL + "api/check_image_zip/",
-                    params: {task_id: taskId},
+                    url: baseURL + "api/check_image_zip/" + taskId,
                     headers: {'X-CSRFToken': Cookies.get('csrftoken') }
                 }).then(res => {
                     if (res.status !== 200) {

--- a/search/src/Components/upload/uploader_zip.js
+++ b/search/src/Components/upload/uploader_zip.js
@@ -29,6 +29,40 @@ function getTusUploadFile(file) {
 }
 
 
+const getZipUploadResponse = ({upload_id, images, filename}) => {
+    return new Promise((resolve, reject) => {
+        const pollPeriod = 200;
+        const body = new FormData()
+        body.append("upload_id", upload_id);
+        body.append("images", images);
+        body.append("upload_image_zip", filename);
+        axios({
+            method: 'post',
+            url: baseURL + "api/unpack_image_zip/",
+            data: body,
+            headers: {'X-CSRFToken': Cookies.get('csrftoken') }
+        }).then(res => {
+            const taskId = res.data.task_id;
+            const poll = () => {
+                axios({
+                    method: 'get',
+                    url: baseURL + "api/check_image_zip/",
+                    params: {task_id: taskId},
+                    headers: {'X-CSRFToken': Cookies.get('csrftoken') }
+                }).then(res => {
+                    if (res.status !== 200) {
+                        // keep waiting
+                        setTimeout(poll, pollPeriod)
+                    } else {
+                        resolve(res)
+                    }
+                })
+            }
+            setTimeout(poll, pollPeriod);
+        }).catch(reject)
+    })
+}
+
 class UploaderUppyZip extends React.Component {
 
     constructor(props) {
@@ -68,16 +102,7 @@ class UploaderUppyZip extends React.Component {
                 this.props.handleErrorMessage("Upload zipfile failed");
                 return;
             }
-            const body = new FormData()
-            body.append("upload_id", this.props.upload_id);
-            body.append("images", this.props.images);
-            body.append("upload_image_zip", filename);
-            axios({
-                method: 'post',
-                url: baseURL + "api/unpack_image_zip/",
-                data: body,
-                headers: {'X-CSRFToken': Cookies.get('csrftoken') }
-            }).then(res => {
+            getZipUploadResponse({ upload_id: this.props.upload_id, images: this.props.images, filename}).then(res => {
                 if( res.data.upload_id === this.props.upload_id ) {
                     if( res.data.missing_images.length === 0 ) {
                         this.props.handleValidation(true);


### PR DESCRIPTION
This will hopefully fix the remaining issue for @mkutu in #557.

Cases not currently handled include:
* if the polling endpoint is never called after celery processing is finished, the task result will never be forgotten. Not a high storage cost, however.
* perhaps we should have a frontend timeout in case celery/redis go down, but django continues to report pending (assuming celery doesn't check it is alive when an AsyncResult is retrieved)...?