### PR TITLE
Zipfiles for older version of a dataset now visible in the summary page

### DIFF
--- a/search/django/weedid/views.py
+++ b/search/django/weedid/views.py
@@ -513,7 +513,11 @@ def upload_info(request, dataset_id):
     upload_entity = Dataset.objects.get(upload_id=dataset_id)
     return HttpResponse(
         json.dumps(
-            {"metadata": upload_entity.metadata, "agcontexts": upload_entity.agcontext}
+            {
+                "metadata": upload_entity.metadata,
+                "agcontexts": upload_entity.agcontext,
+                "head_version": upload_entity.head_version,
+            }
         )
     )
 


### PR DESCRIPTION
They're in a drop-down underneath the yellow downloads button - may need some UX tidying.